### PR TITLE
Fix compile issues on msys2

### DIFF
--- a/sourceview.go
+++ b/sourceview.go
@@ -1,5 +1,6 @@
 package sourceview
 
+// #include <stdlib.h>
 // #cgo pkg-config: gtksourceview-3.0
 // #include <gtksourceview/gtksourcebuffer.h>
 // #include <gtksourceview/gtksourcegutter.h>


### PR DESCRIPTION
I got errors when building on msys2 descrive in https://github.com/linuxerwang/sourceview3/issues/2

```
..\..\go\pkg\mod\github.com\linuxerwang\sourceview3@v0.0.0-20200530202158-9184b497454e\sourceview.go:244:8: could not determine kind of name for C.free
```

This change fix the issues for me and still compiled fine on Linux